### PR TITLE
Fix finish_reason length handling for OpenAI-compatible models

### DIFF
--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -49,7 +49,7 @@ export class GPT {
                 }
                 let completion = await this.openai.chat.completions.create(pack);
                 if (completion.choices[0].finish_reason == 'length')
-                    throw new Error('Context length exceeded'); 
+                    console.warn('Model response stopped with finish_reason=length; returning partial response.');
                 console.log('Received.');
                 res = completion.choices[0].message.content;
             } 


### PR DESCRIPTION
## Summary

OpenAI-compatible chat completion APIs can return `finish_reason: "length"` when generation reaches the configured output-token limit.

Mindcraft currently interprets that as `Context length exceeded`, which can trigger the context-shortening retry path even when the input is well within the model's context window.

This change keeps the partial completion instead of treating `finish_reason: "length"` as proof of a context overflow.

## Why

This was reproduced with a local OpenAI-compatible llama.cpp backend where the model reached `max_tokens` while still being far below the available context window.

Actual context overflow errors using `context_length_exceeded` are still handled by the existing fallback logic.

## Changes

- Stop converting `finish_reason: "length"` into a context-length error
- Preserve the partial generated response
- Leave actual context-overflow handling unchanged

## Scope

One-line behavioral change in `src/models/gpt.js`.