### PR TITLE
Fix/OpenAI api key alias

### DIFF
--- a/src/models/_model_map.js
+++ b/src/models/_model_map.js
@@ -84,6 +84,6 @@ export function createModel(profile) {
     if (!apiMap[profile.api]) {
         throw new Error('Unknown api:', profile.api);
     }
-    const model = new apiMap[profile.api](profile.model, profile.url, profile.params);
+    const model = new apiMap[profile.api](profile.model, profile.url, profile.params, profile.api_key_alias);
     return model;
 }

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -4,10 +4,11 @@ import { strictFormat } from '../utils/text.js';
 
 export class GPT {
     static prefix = 'openai';
-    constructor(model_name, url, params) {
+    constructor(model_name, url, params, api_key_alias=null) {
         this.model_name = model_name;
         this.params = params;
         this.url = url; // store so that we know whether a custom URL has been set
+        this.api_key_alias = api_key_alias || 'OPENAI_API_KEY';
 
         let config = {};
         if (url)
@@ -16,7 +17,7 @@ export class GPT {
         if (hasKey('OPENAI_ORG_ID'))
             config.organization = getKey('OPENAI_ORG_ID');
 
-        config.apiKey = getKey('OPENAI_API_KEY');
+        config.apiKey = getKey(this.api_key_alias);
 
         this.openai = new OpenAIApi(config);
     }


### PR DESCRIPTION
## Summary

Add support for selecting a custom API key for individual OpenAI-compatible model profiles.

Currently, every OpenAI-compatible provider uses `OPENAI_API_KEY`, which makes it difficult to configure multiple providers at the same time.

This adds an optional `api_key_alias` field to model profiles.

## Example

```json
{
  "api": "openai",
  "url": "https://provider.ai/v1",
  "model": "model-name",
  "api_key_alias": "PROVIDER_API_KEY"
}