### PR TITLE
Fix placement of blocks with different item names

### DIFF
--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -29,6 +29,15 @@ export function blacklistCommands(commands) {
 const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/
 const argRegex = /-?\d+(?:\.\d+)?|true|false|"[^"]*"/g;
 
+// Some placeable blocks use a differently named inventory item.
+// Normalize these only for !placeHere so other block/item commands keep their
+// existing semantics.
+const placementItemAliases = {
+    tripwire: 'string',
+    potatoes: 'potato',
+    wheat: 'wheat_seeds',
+};
+
 export function containsCommand(message) {
     const commandMatch = message.match(commandRegex);
     if (commandMatch)
@@ -121,6 +130,9 @@ export function parseCommandMessage(message) {
         if ((arg.startsWith('"') && arg.endsWith('"')) || (arg.startsWith("'") && arg.endsWith("'"))) {
             arg = arg.substring(1, arg.length-1);
         }
+
+        if (commandName === '!placeHere' && param.type === 'BlockOrItemName')
+            arg = placementItemAliases[arg] ?? arg;
         
         //Convert to the correct type
         switch(param.type) {


### PR DESCRIPTION
## Summary

Fix placement of blocks whose Minecraft block ID differs from the corresponding inventory item ID.

Addresses #189.

## Problem

Some placeable blocks cannot be passed directly to `!placeHere` because the block and inventory item use different names.

Examples:

- `tripwire` is placed using `string`
- `potatoes` are placed using `potato`
- `wheat` is planted using `wheat_seeds`

This can cause the agent to correctly identify a block it wants to place but then fail because it looks for an inventory item with the block's name.

## Changes

Add placement-specific item aliases:

```text
tripwire -> string
potatoes -> potato
wheat -> wheat_seeds