### PR TITLE
Use append-only storage for archived conversation history

### DIFF
--- a/src/agent/history.js
+++ b/src/agent/history.js
@@ -1,7 +1,5 @@
-import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
-import { NPCData } from './npc/data.js';
+import { writeFileSync, readFileSync, mkdirSync, existsSync, appendFileSync } from 'fs';
 import settings from './settings.js';
-
 
 export class History {
     constructor(agent) {
@@ -21,7 +19,7 @@ export class History {
         this.max_messages = settings.max_messages;
 
         // Number of messages to remove from current history and save into memory
-        this.summary_chunk_size = 5; 
+        this.summary_chunk_size = 5;
         // chunking reduces expensive calls to promptMemSaving and appendFullHistory
         // and improves the quality of the memory summary
     }
@@ -31,7 +29,7 @@ export class History {
     }
 
     async summarizeMemories(turns) {
-        console.log("Storing memories...");
+        console.log('Storing memories...');
         this.memory = await this.agent.prompter.promptMemSaving(turns);
 
         if (this.memory.length > 500) {
@@ -39,22 +37,21 @@ export class History {
             this.memory += '...(Memory truncated to 500 chars. Compress it more next time)';
         }
 
-        console.log("Memory updated to: ", this.memory);
+        console.log('Memory updated to: ', this.memory);
     }
 
     async appendFullHistory(to_store) {
         if (this.full_history_fp === undefined) {
             const string_timestamp = new Date().toLocaleString().replace(/[/:]/g, '-').replace(/ /g, '').replace(/,/g, '_');
-            this.full_history_fp = `./bots/${this.name}/histories/${string_timestamp}.json`;
-            writeFileSync(this.full_history_fp, '[]', 'utf8');
+            this.full_history_fp = `./bots/${this.name}/histories/${string_timestamp}.jsonl`;
         }
+
         try {
-            const data = readFileSync(this.full_history_fp, 'utf8');
-            let full_history = JSON.parse(data);
-            full_history.push(...to_store);
-            writeFileSync(this.full_history_fp, JSON.stringify(full_history, null, 4), 'utf8');
+            const lines = to_store.map(turn => JSON.stringify(turn)).join('\n');
+            if (lines.length > 0)
+                appendFileSync(this.full_history_fp, lines + '\n', 'utf8');
         } catch (err) {
-            console.error(`Error reading ${this.name}'s full history file: ${err.message}`);
+            console.error(`Error appending ${this.name}'s full history file: ${err.message}`);
         }
     }
 

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { History } from '../src/agent/history.js';
+
+test('archived history is appended as JSONL', async () => {
+    const originalCwd = process.cwd();
+    const dir = mkdtempSync(path.join(tmpdir(), 'mindcraft-history-'));
+    process.chdir(dir);
+
+    try {
+        const agent = {
+            name: 'TestBot',
+            prompter: { promptMemSaving: async () => '' },
+            self_prompter: { state: 0, isStopped: () => true, prompt: '' },
+            task: { taskStartTime: 0 },
+            last_sender: null
+        };
+        const history = new History(agent);
+
+        await history.appendFullHistory([{ role: 'user', content: 'one' }]);
+        await history.appendFullHistory([{ role: 'assistant', content: 'two' }]);
+
+        const lines = readFileSync(history.full_history_fp, 'utf8').trim().split('\n').map(JSON.parse);
+        assert.deepEqual(lines, [
+            { role: 'user', content: 'one' },
+            { role: 'assistant', content: 'two' }
+        ]);
+    } finally {
+        process.chdir(originalCwd);
+        rmSync(dir, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Summary

Refactor full-history persistence to use an append-oriented archive instead of repeatedly reading, parsing, and rewriting the entire history file.

## Problem

The current history archive path grows more expensive as a session gets longer. Each archive update can require loading the full stored history, parsing it, appending new entries, and writing the complete document back to disk.

For long-running autonomous agents this creates unnecessary I/O, memory churn, and increasingly expensive writes.

## Changes

- Move archived full-history storage to an append-only format
- Write new history entries incrementally instead of rewriting the complete archive
- Preserve normal in-memory history behavior
- Keep memory/profile persistence separate from the append-only conversation archive

## Why

Append-only storage scales with the amount of new data being written rather than the total lifetime history size. It is also easier to recover and inspect when a long-running process exits unexpectedly.

## Compatibility

This refactor is scoped to archived history persistence. Agent prompting and active conversation history semantics remain unchanged.

## Validation

Validated on the fork CI matrix with Node 20 and Node 22.
