### PR TITLE
Remove shell interpolation from system TTS execution

### DIFF
--- a/src/agent/speak.js
+++ b/src/agent/speak.js
@@ -65,16 +65,16 @@ function spawnSystemTts(txt) {
 
     if (isWin) {
         const script = [
-            'param([string]$Text)',
             'Add-Type -AssemblyName System.Speech',
             '$s = New-Object System.Speech.Synthesis.SpeechSynthesizer',
             '$s.Rate = 2',
-            '$s.Speak($Text)',
+            '$s.Speak($env:MINDCRAFT_TTS_TEXT)',
             '$s.Dispose()'
         ].join('; ');
-        return spawn('powershell', ['-NoProfile', '-Command', `& { ${script} }`, txt], {
+        return spawn('powershell', ['-NoProfile', '-Command', script], {
             stdio: 'ignore',
-            windowsHide: true
+            windowsHide: true,
+            env: { ...process.env, MINDCRAFT_TTS_TEXT: txt }
         });
     }
 
@@ -111,9 +111,8 @@ async function processQueue() {
     }
 
     if (model === 'system') {
-        // Pass speech text as an argv value rather than interpolating it into a
-        // shell command. This prevents model-controlled text from being parsed
-        // as shell syntax on macOS/Linux or PowerShell syntax on Windows.
+        // Pass speech text outside the shell command so model-controlled text
+        // is never parsed as shell or PowerShell syntax.
         const player = spawnSystemTts(txt);
         let finished = false;
         const finish = () => {

--- a/src/agent/speak.js
+++ b/src/agent/speak.js
@@ -1,4 +1,4 @@
-import { exec, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
@@ -17,9 +17,9 @@ export function speak(text, speak_model) {
         // no preprocessing needed
         item.ready = Promise.resolve();
     } else {
-    item.ready = fetchRemoteAudio(text, model)
-        .then(data => { item.audioData = data; })
-        .catch(err => { item.error = err; });
+        item.ready = fetchRemoteAudio(text, model)
+            .then(data => { item.audioData = data; })
+            .catch(err => { item.error = err; });
     }
 
     speakingQueue.push(item);
@@ -54,6 +54,37 @@ async function fetchRemoteAudio(txt, model) {
     }
 }
 
+function finishQueueItem() {
+    isSpeaking = false;
+    processQueue();
+}
+
+function spawnSystemTts(txt) {
+    const isWin = process.platform === 'win32';
+    const isMac = process.platform === 'darwin';
+
+    if (isWin) {
+        const script = [
+            'param([string]$Text)',
+            'Add-Type -AssemblyName System.Speech',
+            '$s = New-Object System.Speech.Synthesis.SpeechSynthesizer',
+            '$s.Rate = 2',
+            '$s.Speak($Text)',
+            '$s.Dispose()'
+        ].join('; ');
+        return spawn('powershell', ['-NoProfile', '-Command', `& { ${script} }`, txt], {
+            stdio: 'ignore',
+            windowsHide: true
+        });
+    }
+
+    if (isMac) {
+        return spawn('say', [txt], { stdio: 'ignore' });
+    }
+
+    return spawn('espeak', [txt], { stdio: 'ignore' });
+}
+
 async function processQueue() {
     isSpeaking = true;
     if (speakingQueue.length === 0) {
@@ -61,15 +92,13 @@ async function processQueue() {
         return;
     }
     const item = speakingQueue.shift();
-    const { text: txt, model, audioData } = item;
+    const { text: txt, model } = item;
     if (txt.trim() === '') {
-        isSpeaking = false;
-        processQueue();
+        finishQueueItem();
         return;
     }
 
     const isWin = process.platform === 'win32';
-    const isMac = process.platform === 'darwin';
 
     // wait for preprocessing if needed
     try {
@@ -77,74 +106,79 @@ async function processQueue() {
         if (item.error) throw item.error;
     } catch (err) {
         console.error('[TTS] preprocess error', err);
-        isSpeaking = false;
-        processQueue();
+        finishQueueItem();
         return;
     }
 
     if (model === 'system') {
-        // system TTS
-        const cmd = isWin
-            ? `powershell -NoProfile -Command "Add-Type -AssemblyName System.Speech; \
-            $s=New-Object System.Speech.Synthesis.SpeechSynthesizer; $s.Rate=2; \
-            $s.Speak('${txt.replace(/'/g,"''")}'); $s.Dispose()"`
-            : isMac
-            ? `say "${txt.replace(/"/g,'\\"')}"`
-            : `espeak "${txt.replace(/"/g,'\\"')}"`;
-
-        exec(cmd, err => {
-            if (err) console.error('TTS error', err);
-            isSpeaking = false;
-            processQueue();
+        // Pass speech text as an argv value rather than interpolating it into a
+        // shell command. This prevents model-controlled text from being parsed
+        // as shell syntax on macOS/Linux or PowerShell syntax on Windows.
+        const player = spawnSystemTts(txt);
+        let finished = false;
+        const finish = () => {
+            if (finished) return;
+            finished = true;
+            finishQueueItem();
+        };
+        player.on('error', (err) => {
+            console.error('TTS error', err);
+            finish();
         });
+        player.on('exit', finish);
+        return;
+    }
 
-    } 
-    else {
-        // audioData was already fetched in speak()
-        const audioData = item.audioData;
+    // audioData was already fetched in speak()
+    const audioData = item.audioData;
 
-        if (!audioData) {
-            console.error('[TTS] No audio data ready');
-            isSpeaking = false;
-            processQueue();
-            return;
+    if (!audioData) {
+        console.error('[TTS] No audio data ready');
+        finishQueueItem();
+        return;
+    }
+
+    try {
+        if (isWin) {
+            const tmpPath = path.join(os.tmpdir(), `tts_${Date.now()}.mp3`);
+            await fs.writeFile(tmpPath, Buffer.from(audioData, 'base64'));
+
+            const player = spawn('ffplay', ['-nodisp', '-autoexit', '-loglevel', 'quiet', tmpPath], {
+                stdio: 'ignore', windowsHide: true
+            });
+            let finished = false;
+            const finish = async () => {
+                if (finished) return;
+                finished = true;
+                try { await fs.unlink(tmpPath); } catch {}
+                finishQueueItem();
+            };
+            player.on('error', async (err) => {
+                console.error('[TTS] ffplay error', err);
+                await finish();
+            });
+            player.on('exit', finish);
+
+        } else {
+            const player = spawn('ffplay', ['-nodisp','-autoexit','pipe:0'], {
+                stdio: ['pipe','ignore','ignore']
+            });
+            player.stdin.write(Buffer.from(audioData, 'base64'));
+            player.stdin.end();
+            let finished = false;
+            const finish = () => {
+                if (finished) return;
+                finished = true;
+                finishQueueItem();
+            };
+            player.on('error', (err) => {
+                console.error('[TTS] ffplay error', err);
+                finish();
+            });
+            player.on('exit', finish);
         }
-
-        try {
-            if (isWin) {
-                const tmpPath = path.join(os.tmpdir(), `tts_${Date.now()}.mp3`);
-                await fs.writeFile(tmpPath, Buffer.from(audioData, 'base64'));
-
-                const player = spawn('ffplay', ['-nodisp', '-autoexit', '-loglevel', 'quiet', tmpPath], {
-                    stdio: 'ignore', windowsHide: true
-                });
-                player.on('error', async (err) => {
-                    console.error('[TTS] ffplay error', err);
-                    try { await fs.unlink(tmpPath); } catch {}
-                    isSpeaking = false;
-                    processQueue();
-                });
-                player.on('exit', async () => {
-                    try { await fs.unlink(tmpPath); } catch {}
-                    isSpeaking = false;
-                    processQueue();
-                });
-
-            } else {
-                const player = spawn('ffplay', ['-nodisp','-autoexit','pipe:0'], {
-                    stdio: ['pipe','ignore','ignore']
-                });
-                player.stdin.write(Buffer.from(audioData, 'base64'));
-                player.stdin.end();
-                player.on('exit', () => {
-                    isSpeaking = false;
-                    processQueue();
-                });
-            }
-        } catch (e) {
-            console.error('[TTS] Audio error', e);
-            isSpeaking = false;
-            processQueue();
-        }
+    } catch (e) {
+        console.error('[TTS] Audio error', e);
+        finishQueueItem();
     }
 }


### PR DESCRIPTION
## Summary

Harden the system text-to-speech path by removing shell command construction around model-controlled speech text.

## Problem

The macOS/Linux system TTS implementation builds a shell command containing text produced by the model and executes it through a shell.

Escaping quotation marks is not enough to make arbitrary text safe from shell expansion. Shell syntax such as command substitution can still be interpreted before the TTS program receives the text.

## Changes

- Replace shell-based TTS invocation with direct process spawning
- Pass speech text as a process argument rather than interpolating it into a command string
- Preserve the existing platform-specific TTS behavior
- Keep remote/model-based TTS behavior unchanged

## Why

LLM output is untrusted input. It should never be embedded into a shell command when the same program can be invoked directly with an argument array.

## Compatibility

No user-facing configuration changes are required.

## Validation

Validated on the fork CI matrix with Node 20 and Node 22.
