### PR TITLE
Make MindServer startup sequencing explicit

### DIFF
--- a/main.js
+++ b/main.js
@@ -70,11 +70,13 @@ if (process.env.SETTINGS_JSON) {
     }
 }
 
-
-Mindcraft.init(false, settings.mindserver_port, settings.auto_open_ui);
+await Mindcraft.init(false, settings.mindserver_port, settings.auto_open_ui);
 
 for (let profile of settings.profiles) {
     const profile_json = JSON.parse(readFileSync(profile, 'utf8'));
     settings.profile = profile_json;
-    Mindcraft.createAgent(settings);
+    const result = await Mindcraft.createAgent(settings);
+    if (!result.success) {
+        console.error(`Failed to create agent ${profile_json.name}: ${result.error}`);
+    }
 }

--- a/src/mindcraft/mindcraft.js
+++ b/src/mindcraft/mindcraft.js
@@ -9,12 +9,35 @@ let agent_processes = {};
 let agent_count = 0;
 let mindserver_port = 8080;
 
+async function waitForServerListening(server) {
+    if (server.listening) return;
+
+    await new Promise((resolve, reject) => {
+        const onListening = () => {
+            cleanup();
+            resolve();
+        };
+        const onError = (error) => {
+            cleanup();
+            reject(error);
+        };
+        const cleanup = () => {
+            server.off('listening', onListening);
+            server.off('error', onError);
+        };
+
+        server.once('listening', onListening);
+        server.once('error', onError);
+    });
+}
+
 export async function init(host_public=false, port=8080, auto_open_ui=true) {
     if (connected) {
         console.error('Already initiliazed!');
         return;
     }
     mindserver = createMindServer(host_public, port);
+    await waitForServerListening(mindserver);
     mindserver_port = port;
     connected = true;
     if (auto_open_ui) {


### PR DESCRIPTION
## Summary

Make application startup explicitly wait for MindServer readiness before continuing with agent creation.

## Problem

The current startup path launches asynchronous initialization without consistently awaiting each readiness boundary.

That can allow agents to begin connecting to services before the local MindServer has finished listening, creating intermittent startup races and connection failures.

## Changes

- Expose/await MindServer readiness
- Sequence top-level startup operations explicitly
- Start agents only after the server is ready
- Preserve the existing CLI and runtime behavior once startup has completed

## Why

Startup ordering should be deterministic. A service that other components depend on should be confirmed ready before dependent processes are spawned.

## Compatibility

No profile or command changes are introduced.

## Validation

Validated on the fork CI matrix with Node 20 and Node 22.
