### PR TITLE
Normalize environment-backed settings before runtime use

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ import settings from './settings.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { readFileSync } from 'fs';
+import { parseBooleanEnv, parseIntegerEnv, parseJsonEnv } from './src/utils/env.js';
 
 function parseArguments() {
     return yargs(hideBin(process.argv))
@@ -38,35 +39,45 @@ if (args.task_path) {
 }
 
 // these environment variables override certain settings
-if (process.env.MINECRAFT_PORT) {
-    settings.port = process.env.MINECRAFT_PORT;
+if (process.env.MINECRAFT_PORT !== undefined) {
+    settings.port = parseIntegerEnv(process.env.MINECRAFT_PORT, 'MINECRAFT_PORT');
 }
-if (process.env.MINDSERVER_PORT) {
-    settings.mindserver_port = process.env.MINDSERVER_PORT;
+if (process.env.MINDSERVER_PORT !== undefined) {
+    settings.mindserver_port = parseIntegerEnv(process.env.MINDSERVER_PORT, 'MINDSERVER_PORT');
 }
-if (process.env.PROFILES && JSON.parse(process.env.PROFILES).length > 0) {
-    settings.profiles = JSON.parse(process.env.PROFILES);
+if (process.env.PROFILES !== undefined) {
+    const profiles = parseJsonEnv(process.env.PROFILES, 'PROFILES');
+    if (!Array.isArray(profiles)) {
+        throw new Error('PROFILES must be a JSON array.');
+    }
+    if (profiles.length > 0) {
+        settings.profiles = profiles;
+    }
 }
-if (process.env.INSECURE_CODING) {
-    settings.allow_insecure_coding = true;
+if (process.env.INSECURE_CODING !== undefined) {
+    settings.allow_insecure_coding = parseBooleanEnv(process.env.INSECURE_CODING, 'INSECURE_CODING');
 }
-if (process.env.BLOCKED_ACTIONS) {
-    settings.blocked_actions = JSON.parse(process.env.BLOCKED_ACTIONS);
+if (process.env.BLOCKED_ACTIONS !== undefined) {
+    const blockedActions = parseJsonEnv(process.env.BLOCKED_ACTIONS, 'BLOCKED_ACTIONS');
+    if (!Array.isArray(blockedActions)) {
+        throw new Error('BLOCKED_ACTIONS must be a JSON array.');
+    }
+    settings.blocked_actions = blockedActions;
 }
-if (process.env.MAX_MESSAGES) {
-    settings.max_messages = process.env.MAX_MESSAGES;
+if (process.env.MAX_MESSAGES !== undefined) {
+    settings.max_messages = parseIntegerEnv(process.env.MAX_MESSAGES, 'MAX_MESSAGES');
 }
-if (process.env.NUM_EXAMPLES) {
-    settings.num_examples = process.env.NUM_EXAMPLES;
+if (process.env.NUM_EXAMPLES !== undefined) {
+    settings.num_examples = parseIntegerEnv(process.env.NUM_EXAMPLES, 'NUM_EXAMPLES');
 }
-if (process.env.LOG_ALL) {
-    settings.log_all_prompts = process.env.LOG_ALL;
+if (process.env.LOG_ALL !== undefined) {
+    settings.log_all_prompts = parseBooleanEnv(process.env.LOG_ALL, 'LOG_ALL');
 }
 if (process.env.SETTINGS_JSON) {
     try {
-        Object.assign(settings, JSON.parse(process.env.SETTINGS_JSON));
+        Object.assign(settings, parseJsonEnv(process.env.SETTINGS_JSON, 'SETTINGS_JSON'));
     } catch (err) {
-        console.error("Failed to parse environment variable for SETTINGS_JSON:", err);
+        console.error('Failed to parse environment variable for SETTINGS_JSON:', err);
     }
 }
 

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,22 @@
+export function parseBooleanEnv(value, name = 'environment variable') {
+    const normalized = String(value).trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+    throw new Error(`${name} must be a boolean value (true/false, 1/0, yes/no, on/off).`);
+}
+
+export function parseIntegerEnv(value, name = 'environment variable') {
+    const normalized = String(value).trim();
+    if (!/^-?\d+$/.test(normalized)) {
+        throw new Error(`${name} must be an integer.`);
+    }
+    return Number.parseInt(normalized, 10);
+}
+
+export function parseJsonEnv(value, name = 'environment variable') {
+    try {
+        return JSON.parse(value);
+    } catch (error) {
+        throw new Error(`${name} must contain valid JSON: ${error.message}`);
+    }
+}

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseBooleanEnv, parseIntegerEnv, parseJsonEnv } from '../src/utils/env.js';
+
+test('boolean parser does not treat "false" as truthy', () => {
+    assert.equal(parseBooleanEnv('true'), true);
+    assert.equal(parseBooleanEnv('false'), false);
+    assert.equal(parseBooleanEnv('1'), true);
+    assert.equal(parseBooleanEnv('0'), false);
+    assert.throws(() => parseBooleanEnv('maybe'), /must be a boolean/);
+});
+
+test('integer parser returns numbers and rejects mixed values', () => {
+    assert.equal(parseIntegerEnv('42'), 42);
+    assert.equal(parseIntegerEnv('-1'), -1);
+    assert.throws(() => parseIntegerEnv('42px'), /must be an integer/);
+});
+
+test('JSON parser includes the setting name in failures', () => {
+    assert.deepEqual(parseJsonEnv('["a"]'), ['a']);
+    assert.throws(() => parseJsonEnv('{', 'PROFILES'), /PROFILES/);
+});


### PR DESCRIPTION
## Summary

Add proper type normalization for settings loaded from environment variables.

## Problem

Environment variables are strings by default, but several Mindcraft settings are booleans, numbers, arrays, or JSON values.

Without normalization, values such as:

```text
INSECURE_CODING=false
```

can still behave as truthy strings, and numeric settings can remain strings instead of numbers.

## Changes

- Parse boolean environment values explicitly
- Parse integer/numeric settings into numbers
- Parse JSON-backed settings where appropriate
- Preserve existing defaults when an environment variable is not provided
- Avoid silently treating arbitrary non-empty strings as `true`

## Why

Configuration should have the same runtime types regardless of whether it came from `settings.js`, a UI, or environment variables.

Incorrect type handling can change security-sensitive and runtime behavior in surprising ways.

## Compatibility

Existing correctly formatted environment values continue to work; this change makes their interpretation explicit and predictable.

## Validation

Validated on the fork CI matrix with Node 20 and Node 22.
