### PR TITLE
Wait for camera initialization before vision capture

### DIFF
--- a/src/agent/vision/camera.js
+++ b/src/agent/vision/camera.js
@@ -23,11 +23,11 @@ export class Camera extends EventEmitter {
         this.canvas = createCanvas(this.width, this.height);
         this.renderer = new THREE.WebGLRenderer({ canvas: this.canvas });
         this.viewer = new Viewer(this.renderer);
-        this._init().then(() => {
+        this.ready = this._init().then(() => {
             this.emit('ready');
-        })
+        });
     }
-  
+
     async _init () {
         const botPos = this.bot.entity.position;
         const center = new Vec3(botPos.x, botPos.y+this.bot.entity.height, botPos.z);
@@ -39,8 +39,13 @@ export class Camera extends EventEmitter {
         await worldView.init(center);
         this.worldView = worldView;
     }
-  
+
     async capture() {
+        // Camera construction starts world loading asynchronously. A capture can
+        // be requested immediately after construction, so wait for initialization
+        // before dereferencing worldView.
+        await this.ready;
+
         const center = new Vec3(this.bot.entity.position.x, this.bot.entity.position.y+this.bot.entity.height, this.bot.entity.position.z);
         this.viewer.camera.position.set(center.x, center.y, center.z);
         await this.worldView.updatePosition(center);
@@ -53,7 +58,7 @@ export class Camera extends EventEmitter {
             quality: 100,
             progressive: false
         });
-        
+
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
         const filename = `screenshot_${timestamp}`;
 
@@ -65,14 +70,6 @@ export class Camera extends EventEmitter {
     }
 
     async _ensureScreenshotDirectory() {
-        let stats;
-        try {
-            stats = await fs.stat(this.fp);
-        } catch (e) {
-            if (!stats?.isDirectory()) {
-                await fs.mkdir(this.fp);
-            }
-        }
+        await fs.mkdir(this.fp, { recursive: true });
     }
 }
-  


### PR DESCRIPTION
## Summary

Fix a race in the vision camera lifecycle by making captures wait for camera initialization to complete.

## Problem

The camera starts asynchronous initialization from the constructor, but capture calls can arrive before the underlying world/view objects are ready.

That creates an intermittent startup race where vision requests can access uninitialized state.

## Changes

- Track camera initialization with an explicit readiness promise
- Await readiness before performing a capture
- Preserve the existing camera/capture API
- Keep viewer and vision behavior unchanged after initialization

## Why

Asynchronous constructors are not awaitable. Exposing a readiness promise makes the lifecycle explicit and removes timing-dependent behavior.

## Compatibility

No profile or vision-command changes are required.

## Validation

Validated on the fork CI matrix with Node 20 and Node 22.
