### PR TITLE
Make command blacklisting update the active command registry

### DIFF
--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -21,8 +21,12 @@ export function blacklistCommands(commands) {
             console.warn(`Command ${command_name} is unblockable`);
             continue;
         }
+
         delete commandMap[command_name];
-        delete commandList.find(command => command.name === command_name);
+        const index = commandList.findIndex(command => command.name === command_name);
+        if (index !== -1) {
+            commandList.splice(index, 1);
+        }
     }
 }
 

--- a/tests/command_blacklist.test.js
+++ b/tests/command_blacklist.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { blacklistCommands, commandExists, getCommandDocs } from '../src/agent/commands/index.js';
+
+test('blacklisting removes a command from lookup and generated docs', () => {
+    assert.equal(commandExists('!nearbyBlocks'), true);
+    blacklistCommands(['!nearbyBlocks']);
+    assert.equal(commandExists('!nearbyBlocks'), false);
+
+    const docs = getCommandDocs({ blocked_actions: [] });
+    assert.doesNotMatch(docs, /!nearbyBlocks/);
+});


### PR DESCRIPTION
## Summary

Fix command blacklisting so blocked commands are actually removed from the command collections used at runtime.

## Problem

The current blacklist path attempts to remove an array element with `delete commandList.find(...)`.

`Array.prototype.find()` returns the matching value, not its index, and deleting that temporary value does not remove the entry from the array.

This can leave the command map and command arrays out of sync and allow a supposedly blacklisted command to remain discoverable.

## Changes

- Remove blacklisted commands from the underlying command collection correctly
- Keep command lookup structures consistent
- Preserve existing blacklist configuration and command syntax

## Why

Blacklisting should be authoritative. A command that has been disabled should not remain available through another registry representation.

## Compatibility

No changes to command names or profile syntax.

## Validation

Validated on the fork CI matrix with Node 20 and Node 22.
