### PR TITLE
Fix NPC scheduler and item-goal runtime errors

### DIFF
--- a/src/agent/npc/controller.js
+++ b/src/agent/npc/controller.js
@@ -4,8 +4,6 @@ import { ItemGoal } from './item_goal.js';
 import { BuildGoal } from './build_goal.js';
 import { itemSatisfied, rotateXZ } from './utils.js';
 import * as skills from '../library/skills.js';
-import * as world from '../library/world.js';
-import * as mc from '../../utils/mcdata.js';
 
 
 export class NPCContoller {
@@ -17,11 +15,13 @@ export class NPCContoller {
         this.build_goal = new BuildGoal(agent);
         this.constructions = {};
         this.last_goals = {};
+        this.goal_tick_running = false;
     }
 
     getBuiltPositions() {
         let positions = [];
         for (let name in this.data.built) {
+            if (!this.constructions[name]) continue;
             let position = this.data.built[name].position;
             let offset = this.constructions[name].offset;
             let sizex = this.constructions[name].blocks[0][0].length;
@@ -66,15 +66,22 @@ export class NPCContoller {
         }
 
         this.agent.bot.on('idle', async () => {
+            if (this.goal_tick_running) return;
             if (this.data.goals.length === 0 && !this.data.curr_goal) return;
-            // Wait a while for inputs before acting independently
-            await new Promise((resolve) => setTimeout(resolve, 5000));
-            if (!this.agent.isIdle()) return;
 
-            // Persue goal
-            if (!this.agent.actions.resume_func) {
-                this.executeNext();
-                this.agent.history.save();
+            this.goal_tick_running = true;
+            try {
+                // Wait a while for inputs before acting independently
+                await new Promise((resolve) => setTimeout(resolve, 5000));
+                if (!this.agent.isIdle()) return;
+
+                // Pursue goal
+                if (!this.agent.actions.resume_func) {
+                    await this.executeNext();
+                    await this.agent.history.save();
+                }
+            } finally {
+                this.goal_tick_running = false;
             }
         });
     }
@@ -90,7 +97,7 @@ export class NPCContoller {
         if (!this.data.do_set_goal) return;
 
         let past_goals = {...this.last_goals};
-        for (let goal in this.data.goals) {
+        for (let goal of this.data.goals) {
             if (past_goals[goal.name] === undefined) past_goals[goal.name] = true;
         }
         let res = await this.agent.prompter.promptGoalSetting(this.agent.history.getHistory(), past_goals);
@@ -108,7 +115,7 @@ export class NPCContoller {
             await skills.moveAway(this.agent.bot, 2);
         });
 
-        if (!this.data.do_routine || this.agent.bot.time.timeOfDay < 13000) { 
+        if (!this.data.do_routine || this.agent.bot.time.timeOfDay < 13000) {
             // Exit any buildings
             let building = this.currentBuilding();
             if (building == this.data.home) {
@@ -132,9 +139,11 @@ export class NPCContoller {
             let building = this.currentBuilding();
             if (this.data.home !== null && (building === null || building != this.data.home)) {
                 let door_pos = this.getBuildingDoor(this.data.home);
-                await this.agent.actions.runAction('npc:returnHome', async () => {
-                    await skills.useDoor(this.agent.bot, door_pos);
-                });
+                if (door_pos) {
+                    await this.agent.actions.runAction('npc:returnHome', async () => {
+                        await skills.useDoor(this.agent.bot, door_pos);
+                    });
+                }
             }
 
             // Go to bed
@@ -178,6 +187,10 @@ export class NPCContoller {
                     );
                 } else {
                     res = await this.build_goal.executeNext(this.constructions[goal.name]);
+                    if (!res?.position) {
+                        this.last_goals[goal.name] = false;
+                        continue;
+                    }
                     this.data.built[goal.name] = {
                         name: goal.name,
                         position: res.position,
@@ -208,6 +221,7 @@ export class NPCContoller {
     currentBuilding() {
         let bot_pos = this.agent.bot.entity.position;
         for (let name in this.data.built) {
+            if (!this.constructions[name]) continue;
             let pos = this.data.built[name].position;
             let offset = this.constructions[name].offset;
             let sizex = this.constructions[name].blocks[0][0].length;
@@ -224,7 +238,7 @@ export class NPCContoller {
     }
 
     getBuildingDoor(name) {
-        if (name === null || this.data.built[name] === undefined) return null;
+        if (name === null || this.data.built[name] === undefined || !this.constructions[name]) return null;
         let door_x = null;
         let door_z = null;
         let door_y = null;

--- a/src/agent/npc/item_goal.js
+++ b/src/agent/npc/item_goal.js
@@ -160,7 +160,7 @@ class ItemNode {
             await skills.smeltItem(this.manager.agent.bot, to_smelt_name, to_smelt_quantity);
         } else if (this.type === 'hunt') {
             for (let i=0; i<quantity; i++) {
-                res = await skills.attackNearest(this.manager.agent.bot, this.source);
+                const res = await skills.attackNearest(this.manager.agent.bot, this.source);
                 if (!res || this.manager.agent.bot.interrupt_code)
                     break;
             }
@@ -204,22 +204,21 @@ class ItemWrapper {
     }
 
     createChildren() {
-        let recipes = mc.getItemCraftingRecipes(this.name).map(([recipe, craftedCount]) => recipe);
-        if (recipes) {
-            for (let recipe of recipes) {
-                let includes_blacklisted = false;
-                for (let ingredient in recipe) {
-                    for (let match of blacklist) {
-                        if (ingredient.includes(match)) {
-                            includes_blacklisted = true;
-                            break;
-                        }
+        const craftingRecipes = mc.getItemCraftingRecipes(this.name) || [];
+        let recipes = craftingRecipes.map(([recipe]) => recipe);
+        for (let recipe of recipes) {
+            let includes_blacklisted = false;
+            for (let ingredient in recipe) {
+                for (let match of blacklist) {
+                    if (ingredient.includes(match)) {
+                        includes_blacklisted = true;
+                        break;
                     }
-                    if (includes_blacklisted) break;
                 }
-                if (includes_blacklisted) continue;
-                this.add_method(new ItemNode(this.manager, this, this.name).setRecipe(recipe))
+                if (includes_blacklisted) break;
             }
+            if (includes_blacklisted) continue;
+            this.add_method(new ItemNode(this.manager, this, this.name).setRecipe(recipe))
         }
 
         let block_sources = mc.getItemBlockSources(this.name);
@@ -315,8 +314,10 @@ export class ItemGoal {
         let quantity = next_info.quantity;
 
         // Prevent unnecessary attempts to obtain blocks that are not nearby
-        if (next.type === 'block' && !world.getNearbyBlockTypes(this.agent.bot).includes(next.source) ||
-                next.type === 'hunt' && !world.getNearbyEntityTypes(this.agent.bot).includes(next.source)) {
+        const sourceUnavailable =
+            (next.type === 'block' && !world.getNearbyBlockTypes(this.agent.bot).includes(next.source)) ||
+            (next.type === 'hunt' && !world.getNearbyEntityTypes(this.agent.bot).includes(next.source));
+        if (sourceUnavailable) {
             next.fails += 1;
 
             // If the bot has failed to obtain the block before, explore


### PR DESCRIPTION
## Summary

Fix several concrete runtime bugs in the NPC controller and item-goal planner.

## Problem

The NPC path contains errors that can surface during normal execution, including:

- assignment to an undeclared `res` variable in the item-goal hunting path
- iterating goal arrays with `for...in` and then treating the resulting index as the goal object
- asynchronous goal/save operations that are not consistently sequenced

These bugs can prevent NPC goals from progressing or can throw at runtime under ES module strict mode.

## Changes

- Declare and scope result variables correctly
- Iterate goal objects with `for...of`
- Tighten async sequencing around NPC goal updates/persistence
- Preserve existing NPC goal formats and behavior

## Why

These are deterministic correctness bugs in the NPC runtime rather than style-only issues.

## Compatibility

No NPC profile/schema changes are introduced.

## Validation

Validated on the fork CI matrix with Node 20 and Node 22.