### PR TITLE
Add Node 20/22 CI validation for Mindcraft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts --no-audit --no-fund
+
+      - name: Syntax-check JavaScript
+        shell: bash
+        run: |
+          set -euo pipefail
+          find src -type f -name '*.js' -print0 | xargs -0 -n1 node --check
+          node --check main.js
+          node --check settings.js
+
+      - name: Run tests when present
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          tests=(tests/*.test.js)
+          if (( ${#tests[@]} )); then
+            node --test "${tests[@]}"
+          else
+            echo 'No tests found.'
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -f package-lock.json ]]; then
-            npm ci --ignore-scripts --no-audit --no-fund
+            npm ci --no-audit --no-fund
           else
             npm install --ignore-scripts --no-audit --no-fund
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,14 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install dependencies
-        run: npm install --ignore-scripts --no-audit --no-fund
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -f package-lock.json ]]; then
+            npm ci --ignore-scripts --no-audit --no-fund
+          else
+            npm install --ignore-scripts --no-audit --no-fund
+          fi
 
       - name: Syntax-check JavaScript
         shell: bash


### PR DESCRIPTION
## Summary

Add a baseline GitHub Actions workflow for validating Mindcraft changes before merge.

## Checks

The workflow runs against Node 20 and Node 22 and performs:

- dependency installation
- real `npm ci` when a lockfile is present
- `patch-package` postinstall validation for locked installs
- JavaScript syntax checks across `src/`
- syntax checks for top-level runtime files
- focused Node tests when test files are present

## Why

The repository currently has no standard CI gate for pull requests.

Mindcraft has a large async JavaScript runtime, multiple model backends, generated-code paths, and patched dependencies. Even a lightweight CI baseline catches syntax errors, broken installs, and test regressions before they reach `develop`.

## Scope

This PR intentionally starts with deterministic checks that can run without Minecraft credentials, API keys, or external model access.

It does not attempt to run a full Minecraft integration environment in GitHub Actions.

## Compatibility

No runtime behavior changes.

## Validation

The workflow has been exercised successfully on the fork across both Node versions.
