### PR TITLE
Make BuildGoal respect failed action results

### DIFF
--- a/src/agent/npc/build_goal.js
+++ b/src/agent/npc/build_goal.js
@@ -1,7 +1,6 @@
 import { Vec3 } from 'vec3';
 import * as skills from '../library/skills.js';
 import * as world from '../library/world.js';
-import * as mc from '../../utils/mcdata.js';
 import { blockSatisfied, getTypeOfGeneric, rotateXZ } from './utils.js';
 
 
@@ -14,7 +13,7 @@ export class BuildGoal {
         if (!this.agent.isIdle())
             return false;
         let res = await this.agent.actions.runAction('BuildGoal', func);
-        return !res.interrupted;
+        return res.success && !res.interrupted && !res.timedout;
     }
 
     async executeNext(goal, position=null, orientation=null) {
@@ -26,6 +25,9 @@ export class BuildGoal {
                 position = world.getNearestFreeSpace(this.agent.bot, sizex - x, 16);
                 if (position) break;
             }
+        }
+        if (!position) {
+            return {missing: {}, acted: false, position: null, orientation};
         }
         if (orientation === null) {
             orientation = Math.floor(Math.random() * 4);
@@ -64,6 +66,7 @@ export class BuildGoal {
                                     await skills.placeBlock(this.agent.bot, block_typed, world_pos.x, world_pos.y, world_pos.z);
                                 });
                                 if (!res) return {missing: missing, acted: acted, position: position, orientation: orientation};
+                                inventory[block_typed]--;
                             } else {
                                 if (missing[block_typed] === undefined)
                                     missing[block_typed] = 0;


### PR DESCRIPTION
## Summary

Fix BuildGoal progression so a failed build action is not treated as successful progress.

## Problem

The construction planner can treat an action as successful as long as it was not interrupted, even when the returned action result explicitly reports failure.

That can cause the planner to advance its build state after a placement/action that never actually succeeded.

## Changes

- Check the action's actual success result
- Preserve interruption handling separately from ordinary failure
- Avoid advancing construction state on failed actions
- Keep the BuildGoal API and blueprint format unchanged

## Why

Planner state must reflect observed action outcomes. Treating failure as success can corrupt later planning and make recovery much harder for the agent.

## Compatibility

No blueprint or command syntax changes.

## Validation

Validated on the fork CI matrix with Node 20 and Node 22.
