### PR TITLE
Make generated-code templates explicitly awaitable

### DIFF
--- a/src/agent/coder.js
+++ b/src/agent/coder.js
@@ -1,11 +1,12 @@
-import { writeFile, readFile, mkdirSync } from 'fs';
+import { writeFile, mkdirSync } from 'fs';
+import { readFile } from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { makeCompartment, lockdown } from './library/lockdown.js';
 import * as skills from './library/skills.js';
 import * as world from './library/world.js';
 import { Vec3 } from 'vec3';
-import {ESLint} from "eslint";
+import { ESLint } from 'eslint';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -16,23 +17,23 @@ export class Coder {
         this.fp = '/bots/'+agent.name+'/action-code/';
         this.code_template = '';
         this.code_lint_template = '';
-
-        readFile(path.join(__dirname, '../../bots/execTemplate.js'), 'utf8', (err, data) => {
-            if (err) throw err;
-            this.code_template = data;
-        });
-        readFile(path.join(__dirname, '../../bots/lintTemplate.js'), 'utf8', (err, data) => {
-            if (err) throw err;
-            this.code_lint_template = data;
-        });
+        this.ready = this._loadTemplates();
         mkdirSync('.' + this.fp, { recursive: true });
     }
 
+    async _loadTemplates() {
+        [this.code_template, this.code_lint_template] = await Promise.all([
+            readFile(path.join(__dirname, '../../bots/execTemplate.js'), 'utf8'),
+            readFile(path.join(__dirname, '../../bots/lintTemplate.js'), 'utf8'),
+        ]);
+    }
+
     async generateCode(agent_history) {
+        await this.ready;
         this.agent.bot.modes.pause('unstuck');
         lockdown();
         // this message history is transient and only maintained in this function
-        let messages = agent_history.getHistory(); 
+        let messages = agent_history.getHistory();
         messages.push({role: 'system', content: 'Code generation started. Write code in codeblock in your response:'});
 
         const MAX_ATTEMPTS = 5;
@@ -51,21 +52,21 @@ export class Coder {
             if (!contains_code) {
                 if (res.indexOf('!newAction') !== -1) {
                     messages.push({
-                        role: 'assistant', 
+                        role: 'assistant',
                         content: res.substring(0, res.indexOf('!newAction'))
                     });
                     continue; // using newaction will continue the loop
                 }
-                
+
                 if (no_code_failures >= MAX_NO_CODE) {
-                    console.warn("Action failed, agent would not write code.");
+                    console.warn('Action failed, agent would not write code.');
                     return 'Action failed, agent would not write code.';
                 }
                 messages.push({
-                    role: 'system', 
+                    role: 'system',
                     content: 'Error: no code provided. Write code in codeblock in your response. ``` // example ```'}
                 );
-                console.warn("No code block generated. Trying again.");
+                console.warn('No code block generated. Trying again.');
                 no_code_failures++;
                 continue;
             }
@@ -75,12 +76,12 @@ export class Coder {
             const lintResult = await this._lintCode(result.src_lint_copy);
             if (lintResult) {
                 const message = 'Error: Code lint error:'+'\n'+lintResult+'\nPlease try again.';
-                console.warn("Linting error:"+'\n'+lintResult+'\n');
+                console.warn('Linting error:'+'\n'+lintResult+'\n');
                 messages.push({ role: 'system', content: message });
                 continue;
             }
             if (!executionModule) {
-                console.warn("Failed to stage code, something is wrong.");
+                console.warn('Failed to stage code, something is wrong.');
                 return 'Failed to stage code, something is wrong.';
             }
 
@@ -89,12 +90,12 @@ export class Coder {
                 await executionModule.main(this.agent.bot);
 
                 const code_output = this.agent.actions.getBotOutputSummary();
-                const summary = "Agent wrote this code: \n```" + this._sanitizeCode(code) + "```\nCode Output:\n" + code_output;
+                const summary = 'Agent wrote this code: \n```' + this._sanitizeCode(code) + '```\nCode Output:\n' + code_output;
                 return summary;
             } catch (e) {
                 if (this.agent.bot.interrupt_code)
                     return null;
-                
+
                 console.warn('Generated code threw error: ' + e.toString());
                 console.warn('trying again...');
 
@@ -112,23 +113,23 @@ export class Coder {
         }
         return `Code generation failed after ${MAX_ATTEMPTS} attempts.`;
     }
-    
-    async  _lintCode(code) {
+
+    async _lintCode(code) {
         let result = '#### CODE ERROR INFO ###\n';
         const codeNoComments = code.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
         const skillRegex = /((?:skills|world)\.(.*?))\(/g;
-        const skills = [];
+        const usedSkills = [];
         let match;
         while ((match = skillRegex.exec(codeNoComments)) !== null) {
-            skills.push(match[1]);
+            usedSkills.push(match[1]);
         }
         const allDocs = await this.agent.prompter.skill_libary.getAllSkillDocs();
         const knownSkills = new Set(allDocs.map(doc => doc.split('\n')[0]));
-        const missingSkills = skills.filter(skill => !knownSkills.has(skill));
+        const missingSkills = usedSkills.filter(skill => !knownSkills.has(skill));
         if (missingSkills.length > 0) {
             result += 'These functions do not exist:\n';
             result += missingSkills.join('\n');
-            console.log(result)
+            console.log(result);
             return result;
         }
 
@@ -152,11 +153,12 @@ export class Coder {
             return null;//no error
         }
 
-        return result ;
+        return result;
     }
-    // write custom code to file and import it
+
     // write custom code to file and prepare for evaluation
     async _stageCode(code) {
+        await this.ready;
         code = this._sanitizeCode(code);
         let src = '';
         code = code.replaceAll('console.log(', 'log(bot,');
@@ -173,15 +175,8 @@ export class Coder {
         src = this.code_template.replace('/* CODE HERE */', src);
 
         let filename = this.file_counter + '.js';
-        // if (this.file_counter > 0) {
-        //     let prev_filename = this.fp + (this.file_counter-1) + '.js';
-        //     unlink(prev_filename, (err) => {
-        //         console.log("deleted file " + prev_filename);
-        //         if (err) console.error(err);
-        //     });
-        // } commented for now, useful to keep files for debugging
         this.file_counter++;
-        
+
         let write_result = await this._writeFilePromise('.' + this.fp + filename, src);
         // This is where we determine the environment the agent's code should be exposed to.
         // It will only have access to these things, (in addition to basic javascript objects like Array, Object, etc.)
@@ -193,7 +188,7 @@ export class Coder {
             Vec3,
         });
         const mainFn = compartment.evaluate(src);
-        
+
         if (write_result) {
             console.error('Error writing code execution file: ' + write_result);
             return null;
@@ -203,7 +198,7 @@ export class Coder {
 
     _sanitizeCode(code) {
         code = code.trim();
-        const remove_strs = ['Javascript', 'javascript', 'js']
+        const remove_strs = ['Javascript', 'javascript', 'js'];
         for (let r of remove_strs) {
             if (code.startsWith(r)) {
                 code = code.slice(r.length);

--- a/src/agent/coder.js
+++ b/src/agent/coder.js
@@ -6,7 +6,7 @@ import { makeCompartment, lockdown } from './library/lockdown.js';
 import * as skills from './library/skills.js';
 import * as world from './library/world.js';
 import { Vec3 } from 'vec3';
-import { ESLint } from 'eslint';
+import {ESLint} from "eslint";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -17,6 +17,7 @@ export class Coder {
         this.fp = '/bots/'+agent.name+'/action-code/';
         this.code_template = '';
         this.code_lint_template = '';
+
         this.ready = this._loadTemplates();
         mkdirSync('.' + this.fp, { recursive: true });
     }
@@ -24,7 +25,7 @@ export class Coder {
     async _loadTemplates() {
         [this.code_template, this.code_lint_template] = await Promise.all([
             readFile(path.join(__dirname, '../../bots/execTemplate.js'), 'utf8'),
-            readFile(path.join(__dirname, '../../bots/lintTemplate.js'), 'utf8'),
+            readFile(path.join(__dirname, '../../bots/lintTemplate.js'), 'utf8')
         ]);
     }
 
@@ -33,7 +34,7 @@ export class Coder {
         this.agent.bot.modes.pause('unstuck');
         lockdown();
         // this message history is transient and only maintained in this function
-        let messages = agent_history.getHistory();
+        let messages = agent_history.getHistory(); 
         messages.push({role: 'system', content: 'Code generation started. Write code in codeblock in your response:'});
 
         const MAX_ATTEMPTS = 5;
@@ -52,21 +53,21 @@ export class Coder {
             if (!contains_code) {
                 if (res.indexOf('!newAction') !== -1) {
                     messages.push({
-                        role: 'assistant',
+                        role: 'assistant', 
                         content: res.substring(0, res.indexOf('!newAction'))
                     });
                     continue; // using newaction will continue the loop
                 }
-
+                
                 if (no_code_failures >= MAX_NO_CODE) {
-                    console.warn('Action failed, agent would not write code.');
+                    console.warn("Action failed, agent would not write code.");
                     return 'Action failed, agent would not write code.';
                 }
                 messages.push({
-                    role: 'system',
+                    role: 'system', 
                     content: 'Error: no code provided. Write code in codeblock in your response. ``` // example ```'}
                 );
-                console.warn('No code block generated. Trying again.');
+                console.warn("No code block generated. Trying again.");
                 no_code_failures++;
                 continue;
             }
@@ -76,12 +77,12 @@ export class Coder {
             const lintResult = await this._lintCode(result.src_lint_copy);
             if (lintResult) {
                 const message = 'Error: Code lint error:'+'\n'+lintResult+'\nPlease try again.';
-                console.warn('Linting error:'+'\n'+lintResult+'\n');
+                console.warn("Linting error:"+'\n'+lintResult+'\n');
                 messages.push({ role: 'system', content: message });
                 continue;
             }
             if (!executionModule) {
-                console.warn('Failed to stage code, something is wrong.');
+                console.warn("Failed to stage code, something is wrong.");
                 return 'Failed to stage code, something is wrong.';
             }
 
@@ -90,12 +91,12 @@ export class Coder {
                 await executionModule.main(this.agent.bot);
 
                 const code_output = this.agent.actions.getBotOutputSummary();
-                const summary = 'Agent wrote this code: \n```' + this._sanitizeCode(code) + '```\nCode Output:\n' + code_output;
+                const summary = "Agent wrote this code: \n```" + this._sanitizeCode(code) + "```\nCode Output:\n" + code_output;
                 return summary;
             } catch (e) {
                 if (this.agent.bot.interrupt_code)
                     return null;
-
+                
                 console.warn('Generated code threw error: ' + e.toString());
                 console.warn('trying again...');
 
@@ -113,8 +114,8 @@ export class Coder {
         }
         return `Code generation failed after ${MAX_ATTEMPTS} attempts.`;
     }
-
-    async _lintCode(code) {
+    
+    async  _lintCode(code) {
         let result = '#### CODE ERROR INFO ###\n';
         const codeNoComments = code.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
         const skillRegex = /((?:skills|world)\.(.*?))\(/g;
@@ -129,7 +130,7 @@ export class Coder {
         if (missingSkills.length > 0) {
             result += 'These functions do not exist:\n';
             result += missingSkills.join('\n');
-            console.log(result);
+            console.log(result)
             return result;
         }
 
@@ -153,9 +154,9 @@ export class Coder {
             return null;//no error
         }
 
-        return result;
+        return result ;
     }
-
+    // write custom code to file and import it
     // write custom code to file and prepare for evaluation
     async _stageCode(code) {
         await this.ready;
@@ -175,8 +176,15 @@ export class Coder {
         src = this.code_template.replace('/* CODE HERE */', src);
 
         let filename = this.file_counter + '.js';
+        // if (this.file_counter > 0) {
+        //     let prev_filename = this.fp + (this.file_counter-1) + '.js';
+        //     unlink(prev_filename, (err) => {
+        //         console.log("deleted file " + prev_filename);
+        //         if (err) console.error(err);
+        //     });
+        // } commented for now, useful to keep files for debugging
         this.file_counter++;
-
+        
         let write_result = await this._writeFilePromise('.' + this.fp + filename, src);
         // This is where we determine the environment the agent's code should be exposed to.
         // It will only have access to these things, (in addition to basic javascript objects like Array, Object, etc.)
@@ -188,7 +196,7 @@ export class Coder {
             Vec3,
         });
         const mainFn = compartment.evaluate(src);
-
+        
         if (write_result) {
             console.error('Error writing code execution file: ' + write_result);
             return null;
@@ -198,7 +206,7 @@ export class Coder {
 
     _sanitizeCode(code) {
         code = code.trim();
-        const remove_strs = ['Javascript', 'javascript', 'js'];
+        const remove_strs = ['Javascript', 'javascript', 'js']
         for (let r of remove_strs) {
             if (code.startsWith(r)) {
                 code = code.slice(r.length);


### PR DESCRIPTION
## Summary

Fix the generated-code initialization race by making template readiness explicit before code generation begins.

## Problem

`Coder` starts asynchronous file reads from its constructor, but callers can invoke code generation immediately.

If generation wins the race, template strings may still be empty or partially initialized.

## Changes

- Track template initialization with an explicit readiness promise
- Await template readiness before generated-code operations
- Preserve the existing Coder API and output file behavior
- Avoid relying on callback timing during startup

## Why

Generated-code execution is complex enough without timing-dependent initialization. Template availability should be a guaranteed precondition.

## Compatibility

No generated-code prompt format or command changes are introduced.

## Validation

Validated on the fork CI matrix with Node 20 and Node 22.
