### PR TITLE
Refactor LAN Minecraft server discovery for bounded concurrency

### DIFF
--- a/src/mindcraft/mcserver.js
+++ b/src/mindcraft/mcserver.js
@@ -2,103 +2,120 @@ import net from 'net';
 import mc from 'minecraft-protocol';
 
 /**
- * Scans the IP address for Minecraft LAN servers and collects their info.
+ * Pings a Minecraft server and returns its advertised metadata.
  * @param {string} ip - The IP address to scan.
  * @param {number} port - The port to check.
  * @param {number} timeout - The connection timeout in ms.
  * @param {boolean} verbose - Whether to print output on connection errors.
- * @returns {Promise<Array>} - A Promise that resolves to an array of server info objects.
+ * @returns {Promise<Object|null>}
  */
 export async function serverInfo(ip, port, timeout = 1000, verbose = false) {
     return new Promise((resolve) => {
+        let settled = false;
+        const finish = (value) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeoutId);
+            resolve(value);
+        };
 
-        let timeoutId = setTimeout(() => {
+        const timeoutId = setTimeout(() => {
             if (verbose)
                 console.error(`Timeout pinging server ${ip}:${port}`);
-            resolve(null); // Resolve as null if no response within timeout
+            finish(null);
         }, timeout);
 
         mc.ping({
             host: ip,
             port
         }, (err, response) => {
-            clearTimeout(timeoutId);
-
             if (err) {
                 if (verbose)
                     console.error(`Error pinging server ${ip}:${port}`, err);
-                return resolve(null);
+                return finish(null);
             }
 
             // extract version number from modded servers like "Paper 1.21.4"
             const version = response?.version?.name || '';
             const match = String(version).match(/\d+\.\d+(?:\.\d+)?/);
             const numericVersion = match ? match[0] : null;
-            if (numericVersion !== version) {
+            if (verbose && numericVersion !== version) {
                 console.log(`Modded server found (${version}), attempting to use ${numericVersion}...`);
             }
 
-            const serverInfo = {
+            const description = response?.description;
+            const name = typeof description === 'string'
+                ? description
+                : description?.text || 'No description provided.';
+
+            finish({
                 host: ip,
                 port,
-                name: response.description.text || 'No description provided.',
-                ping: response.latency,
+                name,
+                ping: response?.latency,
                 version: numericVersion
-            };
-
-            resolve(serverInfo);
+            });
         });
     });
 }
 
+function checkPort(ip, port, timeout) {
+    return new Promise((resolve) => {
+        const socket = net.createConnection({ host: ip, port, timeout });
+        let settled = false;
+
+        const finish = (value) => {
+            if (settled) return;
+            settled = true;
+            socket.destroy();
+            resolve(value);
+        };
+
+        socket.once('connect', () => finish(port));
+        socket.once('error', () => finish(null));
+        socket.once('timeout', () => finish(null));
+    });
+}
+
 /**
- * Scans the IP address for Minecraft LAN servers and collects their info.
+ * Scans the normal Minecraft LAN port range using bounded concurrency.
  * @param {string} ip - The IP address to scan.
- * @param {boolean} earlyExit - Whether to exit early after finding a server.
- * @param {number} timeout - The connection timeout in ms.
- * @returns {Promise<Array>} - A Promise that resolves to an array of server info objects.
+ * @param {boolean} earlyExit - Whether to stop once a server is found.
+ * @param {number} timeout - Per-port TCP timeout in ms.
+ * @returns {Promise<Array>}
  */
 export async function findServers(ip, earlyExit = false, timeout = 100) {
     const servers = [];
     const startPort = 49000;
     const endPort = 65000;
+    const concurrency = 64;
+    let nextPort = startPort;
+    let stop = false;
 
-    const checkPort = (port) => {
-        return new Promise((resolve) => {
-            const socket = net.createConnection({ host: ip, port, timeout }, () => {
-                socket.end();
-                resolve(port); // Port is open
-            });
+    async function worker() {
+        while (!stop) {
+            const port = nextPort++;
+            if (port > endPort) return;
 
-            socket.on('error', () => resolve(null)); // Port is closed
-            socket.on('timeout', () => {
-                socket.destroy();
-                resolve(null);
-            });
-        });
-    };
+            const openPort = await checkPort(ip, port, timeout);
+            if (!openPort || stop) continue;
 
-    // This supresses a lot of annoying console output from the mc library
-    // TODO: find a better way to do this, it supresses other useful output
-    const originalConsoleLog = console.log;
-    console.log = () => { };
-    
-    for (let port = startPort; port <= endPort; port++) {
-        const openPort = await checkPort(port);
-        if (openPort) {
-            const server = await serverInfo(ip, port, 200, false);
-            if (server) {
-                servers.push(server);
+            const server = await serverInfo(ip, openPort, 200, false);
+            if (!server || stop) continue;
 
-                if (earlyExit) break;
+            servers.push(server);
+            if (earlyExit) {
+                stop = true;
+                return;
             }
         }
     }
 
-    // Restore console output
-    console.log = originalConsoleLog;
+    const workerCount = Math.min(concurrency, endPort - startPort + 1);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+    servers.sort((a, b) => a.port - b.port);
 
-    return servers;
+    return earlyExit ? servers.slice(0, 1) : servers;
 }
 
 /**
@@ -110,42 +127,46 @@ export async function findServers(ip, earlyExit = false, timeout = 100) {
  */
 export async function getServer(host, port, version) {
     let server = null;
-    let serverString = "";
-    let serverVersion = "";
-    
+    let serverString = '';
+    let serverVersion = '';
+
     // Search for server
-    if (port == -1)
-    {
+    if (port == -1) {
         console.log(`No port provided. Searching for LAN server on host ${host}...`);
-        
-        await findServers(host, true).then((servers) => {
-            if (servers.length > 0)
-                server = servers[0];
-        });
+        const servers = await findServers(host, true);
+        if (servers.length > 0)
+            server = servers[0];
 
         if (server == null)
-            throw new Error(`No server found on LAN.`);
+            throw new Error('No server found on LAN.');
     }
-    else
+    else {
         server = await serverInfo(host, port, 1000, true);
+    }
 
     // Server not found
-    if (server == null) 
+    if (server == null)
         throw new Error(`MC server not found. (Host: ${host}, Port: ${port}) Check the host and port in settings.js, and ensure the server is running and open to public or LAN.`);
 
     serverString = `(Host: ${server.host}, Port: ${server.port}, Version: ${server.version})`;
 
-    if (version === "auto") 
+    if (version === 'auto')
         serverVersion = server.version;
     else
         serverVersion = version;
+
+    if (!serverVersion) {
+        throw new Error(`MC server was found ${serverString}, but its Minecraft version could not be determined.`);
+    }
+
     // Server version unsupported / mismatch
-    const isSupported = mc.supportedVersions.some(v => 
+    const isSupported = mc.supportedVersions.some(v =>
         serverVersion === v || (serverVersion.startsWith(v) && serverVersion.charAt(v.length) === '.')
     ); // Checks version or parent version (e.g. if 1.7 is supported then 1.7.2 will be allowed)
-     if (!isSupported)
-        throw new Error(`MC server was found ${serverString}, but version is unsupported. Supported versions are: ${mc.supportedVersions.join(", ")}.`);
-    else if (version !== "auto" && server.version !== version)
+
+    if (!isSupported)
+        throw new Error(`MC server was found ${serverString}, but version is unsupported. Supported versions are: ${mc.supportedVersions.join(', ')}.`);
+    else if (version !== 'auto' && server.version !== version)
         throw new Error(`MC server was found ${serverString}, but version is incorrect. Expected ${version}, but found ${server.version}. Check the server version in settings.js.`);
     else
         console.log(`MC server found. ${serverString}`);


### PR DESCRIPTION
## Summary

Refactor LAN server discovery to scan more efficiently without mutating global logging state.

## Problem

The existing discovery path scans a large port range sequentially and temporarily replaces `console.log` to suppress noisy connection output.

That creates two problems:

- discovery is unnecessarily slow
- global logging behavior is modified for unrelated code and can remain suppressed if an unexpected error occurs

## Changes

- Use bounded concurrent connection attempts for LAN discovery
- Remove global `console.log` replacement
- Keep discovery results and caller-facing behavior compatible
- Ensure scan failures are contained to the individual probe

## Why

Network discovery is naturally parallelizable and should not require global side effects.

## Compatibility

No CLI or server-selection changes are required.

## Validation

Validated on the fork CI matrix with Node 20 and Node 22.
