### PR TITLE
Prevent stop marker from mutating OpenAI-compatible prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "scripts": {
         "postinstall": "patch-package",
         "start": "node main.js",
+        "test": "node --test",
         "reinstall": "npm run clean:modules && npm install",
         "clean:modules": "node -e \"const fs=require('fs');const p=require('path');['node_modules','package-lock.json'].forEach(f=>{if(fs.existsSync(f)){if(fs.lstatSync(f).isDirectory()){fs.rmSync(f,{recursive:true,force:true});}else{fs.unlinkSync(f);}}});\""
     },

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -22,11 +22,6 @@ export class GPT {
     }
 
     async sendRequest(turns, systemMessage, stop_seq='***') {
-        let messages = strictFormat(turns);
-        messages = messages.map(message => {
-            message.content += stop_seq;
-            return message;
-        });
         let model = this.model_name || "gpt-5.4-mini";
 
         let res = null;
@@ -36,7 +31,9 @@ export class GPT {
             // if a custom URL is set, use chat.completions
             // because custom "OpenAI-compatible" endpoints likely do not have responses endpoint
             if (this.url) {
-                let messages = [{'role': 'system', 'content': systemMessage}].concat(turns);
+                let messages = [{'role': 'system', 'content': systemMessage}]
+                    .concat(turns)
+                    .map(message => ({...message}));
                 messages = strictFormat(messages);
                 const pack = {
                     model: model,
@@ -55,7 +52,7 @@ export class GPT {
             } 
             // otherwise, use responses
             else {
-                let messages = strictFormat(turns);
+                let messages = strictFormat(turns.map(message => ({...message})));
                 messages = messages.map(message => {
                     message.content += stop_seq;
                     return message;

--- a/test/gpt.test.js
+++ b/test/gpt.test.js
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import process from 'node:process';
+import test from 'node:test';
+import { GPT } from '../src/models/gpt.js';
+
+function createGPT(url) {
+    const previousKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = 'test-key';
+    try {
+        return new GPT('unit-test-model', url);
+    } finally {
+        if (previousKey === undefined)
+            delete process.env.OPENAI_API_KEY;
+        else
+            process.env.OPENAI_API_KEY = previousKey;
+    }
+}
+
+test('custom endpoints receive unmodified messages without mutating turns', async () => {
+    const gpt = createGPT('http://localhost:8080/v1');
+    const turns = [
+        {role: 'user', content: ' hello '},
+        {role: 'assistant', content: 'world'}
+    ];
+    const originalTurns = structuredClone(turns);
+    let request;
+
+    gpt.openai.chat.completions.create = (pack) => {
+        request = structuredClone(pack);
+        return Promise.resolve({
+            choices: [{
+                finish_reason: 'stop',
+                message: {content: 'adapter-ok'}
+            }]
+        });
+    };
+
+    const response = await gpt.sendRequest(turns, 'system prompt', '<STOP>');
+
+    assert.equal(response, 'adapter-ok');
+    assert.deepEqual(turns, originalTurns);
+    assert.equal(request.stop, '<STOP>');
+    assert.deepEqual(request.messages, [
+        {role: 'user', content: 'SYSTEM: system prompt\nhello'},
+        {role: 'assistant', content: 'world'}
+    ]);
+});
+
+test('Responses API prompt shaping does not mutate turns', async () => {
+    const gpt = createGPT();
+    const turns = [
+        {role: 'user', content: 'hello'},
+        {role: 'assistant', content: 'world'}
+    ];
+    const originalTurns = structuredClone(turns);
+    let request;
+
+    gpt.openai.responses.create = (pack) => {
+        request = structuredClone(pack);
+        return Promise.resolve({output_text: 'responses-ok***ignored'});
+    };
+
+    const response = await gpt.sendRequest(turns, 'system prompt');
+
+    assert.equal(response, 'responses-ok');
+    assert.deepEqual(turns, originalTurns);
+    assert.deepEqual(request.input, [
+        {role: 'user', content: 'hello***'},
+        {role: 'assistant', content: 'world***'}
+    ]);
+});


### PR DESCRIPTION
## Summary

- avoid mutating caller-owned chat turns while formatting GPT requests
- apply stop-marker prompt shaping only to the OpenAI Responses API path
- add regression coverage for custom OpenAI-compatible and Responses requests

## Root cause

`sendRequest` previously ran `strictFormat(turns)` and appended `stop_seq` before choosing an API path. Both operations mutate the message objects. When a custom URL selected `chat.completions`, that branch reused the same turns, so the stop marker was sent inside the prompt as well as in the `stop` request option.

Some OpenAI-compatible servers can interpret a stop marker already present in the prompt as an immediate stop and return an empty completion. The mutation also leaked back into Mindcraft's conversation history and could accumulate across retries.

## Fix

Clone messages before passing them to `strictFormat`, and append the prompt stop marker only in the Responses API branch. Custom endpoints continue to receive the existing `stop` option, while their message content remains clean.

## Validation

- `npm test` on Node 18.20.8, 20.20.2, and 22.23.2
- two regression tests covering custom endpoint payloads, caller immutability, Responses prompt shaping, and output truncation
- manually reproduced the empty response with a llama.cpp OpenAI-compatible endpoint before the fix and confirmed a non-empty response afterward
